### PR TITLE
Implementación de edición y limpieza de tareas

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,6 +19,7 @@
             <button class="filter-btn active" data-filter="all">Todas</button>
             <button class="filter-btn" data-filter="pending">Pendientes</button>
             <button class="filter-btn" data-filter="completed">Completadas</button>
+            <button id="deleteCompletedBtn">Eliminar completadas</button>
         </div>
 
         <div id="tasksList" class="tasks-list">

--- a/styles.css
+++ b/styles.css
@@ -114,6 +114,26 @@ button {
     background-color: #cc0000;
 }
 
+.edit-btn {
+    background-color: #ffc107;
+    color: #333;
+    padding: 5px 10px;
+    margin-right: 10px;
+}
+
+.edit-btn:hover {
+    background-color: #e0a800;
+}
+
+#deleteCompletedBtn {
+    background-color: #ff9800;
+    color: white;
+}
+
+#deleteCompletedBtn:hover {
+    background-color: #fb8c00;
+}
+
 .stats {
     display: flex;
     justify-content: space-between;


### PR DESCRIPTION
## Summary
- unificar renderizado de tareas y filtros en `renderTasks`
- manejar carga desde localStorage con `try/catch`
- permitir edición de tareas y limpiar completadas
- agregar botón de borrado de tareas completadas
- estilos para botones de edición y limpieza

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6849796c8bbc83258304d224498001de